### PR TITLE
Increase GitHub Action checkout version to v5 

### DIFF
--- a/github-modify/action.yml
+++ b/github-modify/action.yml
@@ -19,6 +19,7 @@ runs:
         repository: jbaublitz/${{ inputs.repo }}
         path: jbaublitz
         ref: ${{ github.head_ref }}
+        persist-credentials: false
     - name: Check out mulkieran/${{ inputs.repo }}
       if: github.event_name == 'pull_request'
       id: mulkieran
@@ -28,6 +29,7 @@ runs:
         repository: mulkieran/${{ inputs.repo }}
         path: mulkieran
         ref: ${{ github.head_ref }}
+        persist-credentials: false
     - name: Check if both checkouts succeeded
       if: github.event_name == 'pull_request' && steps.jbaublitz.outcome == 'success' && steps.mulkieran.outcome == 'success'
       shell: bash
@@ -49,3 +51,4 @@ runs:
         repository: stratis-storage/${{ inputs.repo }}
         path: ${{ inputs.repo }}
         ref: master
+        persist-credentials: false

--- a/github-modify/action.yml
+++ b/github-modify/action.yml
@@ -14,7 +14,7 @@ runs:
       if: github.event_name == 'pull_request'
       id: jbaublitz
       continue-on-error: true
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: jbaublitz/${{ inputs.repo }}
         path: jbaublitz
@@ -23,7 +23,7 @@ runs:
       if: github.event_name == 'pull_request'
       id: mulkieran
       continue-on-error: true
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: mulkieran/${{ inputs.repo }}
         path: mulkieran
@@ -44,7 +44,7 @@ runs:
       run: mv mulkieran ${{ inputs.repo }}
     - name: Check out stratis-storage repo if no alternative branch was checked out
       if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && steps.mulkieran.outcome == 'failure' && steps.jbaublitz.outcome == 'failure')
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: stratis-storage/${{ inputs.repo }}
         path: ${{ inputs.repo }}


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use the latest checkout action (v5).
  * Disabled credential persistence in checkout steps to improve security.
  * No changes to the sequence or behavior of existing checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->