### PR TITLE
github-modify: Allow specifying default branch

### DIFF
--- a/github-modify/action.yml
+++ b/github-modify/action.yml
@@ -6,6 +6,10 @@ inputs:
   repo:
     description: "The name of the GitHub repo"
     required: true
+  default_branch:
+    description: "The default branch to check out if no overrides"
+    required: false
+    default: 'master'
 runs:
   using: "composite"
   steps:
@@ -49,5 +53,5 @@ runs:
       with:
         repository: stratis-storage/${{ inputs.repo }}
         path: ${{ inputs.repo }}
-        ref: master
+        ref: ${{ inputs.default_branch }}
         persist-credentials: false


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "default_branch" input to the action so you can set which branch is checked out when no override is provided. Defaults to "master", making the action compatible with repositories using "main" or other custom default branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->