### PR TITLE
Remove type descriptor for inputs

### DIFF
--- a/github-modify/action.yml
+++ b/github-modify/action.yml
@@ -6,7 +6,6 @@ inputs:
   repo:
     description: "The name of the GitHub repo"
     required: true
-    type: string
 runs:
   using: "composite"
   steps:

--- a/stratisd-modify/action.yml
+++ b/stratisd-modify/action.yml
@@ -7,7 +7,6 @@ inputs:
     description: "The working directory for this action"
     required: false
     default: '.'
-    type: string
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated GitHub Actions input definitions by removing explicit type annotations for certain inputs.
  - Harmonized input schemas across actions to streamline configuration.
  - No changes to action behavior or workflow steps; existing workflows continue to run as before.
  - Users do not need to modify their workflow files; defaults and required inputs remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->